### PR TITLE
Preventing duplicate markers

### DIFF
--- a/lib/oms.coffee
+++ b/lib/oms.coffee
@@ -84,7 +84,7 @@ class @['OverlappingMarkerSpiderfier']
   p['removeMarker'] = (marker) ->
     @['unspiderfy']() if marker['_omsData']?  # otherwise it'll be stuck there forever!
     i = @arrIndexOf(@markers, marker)
-    return if i < 0
+    return @ if i < 0
     listenerRefs = @markerListenerRefs.splice(i, 1)[0]
     ge.removeListener(listenerRef) for listenerRef in listenerRefs
     @markers.splice(i, 1)
@@ -200,7 +200,7 @@ class @['OverlappingMarkerSpiderfier']
     @trigger('spiderfy', spiderfiedMarkers, nonNearbyMarkers)
   
   p['unspiderfy'] = (markerNotToMove = null) ->
-    return unless @spiderfied?
+    return @ unless @spiderfied?
     @unspiderfying = yes
     unspiderfiedMarkers = []
     nonNearbyMarkers = []


### PR DESCRIPTION
Hi jawj,

This is an excellent library you have written! It works very well and plays nicely with MarkerClusterer.

I added a check on the addMarker method to see whether the marker has already been added to OMS. MarkerClusterer does this check. This will prevent adding duplicate markers/event listeners if the addMarker function is passed a marker OMS is already observing. I was running into this problem in my application.

I also added a couple of changes so that methods which have checks will be chainable even if the check fails.

Thanks,

Eric
