### PR TITLE
Compatibility with Josh Livni's Earth API library

### DIFF
--- a/lib/oms.coffee
+++ b/lib/oms.coffee
@@ -138,7 +138,7 @@ class @['OverlappingMarkerSpiderfier']
   p.spiderListener = (marker) ->
     markerSpiderfied = marker['_omsData']?
     @['unspiderfy']() unless markerSpiderfied and @['keepSpiderfied']
-    if markerSpiderfied or @map.getStreetView().getVisible()  # don't spiderfy in Street View!
+    if markerSpiderfied or @map.getStreetView().getVisible() or @map.getMapTypeId() is 'GoogleEarthAPI'  # don't spiderfy in Street View or GE Plugin!
       @trigger('click', marker)
     else
       nearbyMarkerData = []


### PR DESCRIPTION
Hi George,

Great library - many thanks for writing it! This is a small fix to avoid spiderfying in GE Plugin mode, if Google's Earth API library for Maps v3 is used to switch between 2D Maps and 3D Earth (while showing the same markers in both Maps/Earth).

(I'm new to github so just let me know if I did any mistakes on the fork+pull steps)

Many thanks,
David
