### PR TITLE
Fix reference to forgetAllMarkers

### DIFF
--- a/lib/oms.coffee
+++ b/lib/oms.coffee
@@ -150,7 +150,7 @@ class @['OverlappingMarkerSpiderfier']
   
   p['removeAllMarkers'] = p['clearMarkers'] = ->  # much quicker than calling removeMarker for each marker; clearMarkers is deprecated as unclear
     markers = @['getMarkers']()
-    @[forgetAllMarkers]()
+    @['forgetAllMarkers']()
     marker.setMap(null) for marker in markers
     @
 


### PR DESCRIPTION
This will prevent the error `Uncaught ReferenceError: forgetAllMarkers is not defined` when calling `removeAllMarkers`